### PR TITLE
add solution week8(0327 ~ 0331)

### DIFF
--- a/오혜윤/20250327/P2805.java
+++ b/오혜윤/20250327/P2805.java
@@ -1,0 +1,36 @@
+// [실버2] 2805번. 나무 자르기
+// 메모리 : 167844 KB, 시간 : 448 ms
+
+import java.io.*;
+import java.util.*;
+
+public class P2805 {
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken());	// 나무의 수
+		int M = Integer.parseInt(st.nextToken());	// 필요한 나무의 길이
+		
+		int start = 0, mid = 0, end = 0, result = 0;
+		
+		int[] heights = new int[N];	// 나무의 높이
+		st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < N; i++) {
+			heights[i] = Integer.parseInt(st.nextToken());
+			end = Math.max(end, heights[i]);
+		}
+		
+		while (start <= end) {
+			mid = (start + end) / 2;
+			long sum = 0;
+			
+			for (int height : heights) {
+				if (height > mid) sum += (height - mid);
+			}
+			
+			if (sum < M) end = mid - 1;
+			else start = mid + 1;
+		}
+		System.out.println(end);
+	}
+}

--- a/오혜윤/20250328/P2110.java
+++ b/오혜윤/20250328/P2110.java
@@ -1,0 +1,50 @@
+// [골드4] 2110번. 공유기 설치
+// 메모리 : 28396 KB, 시간 : 244 ms
+
+import java.io.*;
+import java.util.*;
+
+public class P2110 {
+	static int N, C;
+	static int[] houses;
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());	// 집의 개수
+		C = Integer.parseInt(st.nextToken());	// 공유기의 개수
+		
+		houses = new int[N];
+		for (int i = 0; i < N; i++) {
+			houses[i] = Integer.parseInt(br.readLine());
+		}
+		Arrays.sort(houses);
+		
+		int start = 1, end = houses[N-1] - houses[0];
+		while (start <= end) {
+			int mid = (start + end) / 2;	// 공유기 설치 간격
+			
+			// 설치 불가능 -> 간격 더 줄여보기
+			if (!install(mid, new ArrayList<>())) end = mid - 1;
+			
+			// 설치 가능 -> 간격 더 늘려보기
+			else start = mid + 1;
+		}
+		System.out.println(end);
+	}
+	
+	static boolean install(int mid, List<Integer> current) {
+		int cnt = 1;	// 현재까지 설치된 공유기 개수
+		int last = houses[0];	// 가장 최근 설치한 집
+		
+		for (int i = 1; i < N; i++) {
+			if (cnt >= C) return true;
+			
+			if (houses[i] - last < mid) continue;
+			last = houses[i];
+			cnt++;
+		}
+		
+		if (cnt < C) return false;
+		return true;
+	}
+}

--- a/오혜윤/20250329/P1300.java
+++ b/오혜윤/20250329/P1300.java
@@ -1,0 +1,31 @@
+// [골드1] 1300번. K번째 수
+// 메모리 : 11600 KB, 시간 : 104 ms
+
+import java.io.*;
+
+public class P1300 {
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		long N = Integer.parseInt(br.readLine());
+		long k = Integer.parseInt(br.readLine());
+		
+		long answer = 0, start = 1, end = k;
+		
+		while (start <= end) {
+			long mid = (start + end) / 2;
+			
+			long cnt = 0;
+			for (int i = 1; i <= N; i++) {
+				cnt += Math.min(mid / i, N);
+			}
+			
+			if (cnt >= k) {
+				answer = mid;
+				end = mid - 1;
+			}
+			
+			else start = mid + 1;
+		}
+		System.out.println(answer);
+	}
+}

--- a/오혜윤/20250330/P12015.java
+++ b/오혜윤/20250330/P12015.java
@@ -1,0 +1,34 @@
+// [골드2] 12015번. 가장 긴 증가하는 부분 수열 2
+// 메모리 : 125320 KB, 시간 : 444 ms
+
+import java.io.*;
+import java.util.*;
+
+public class P12015 {
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		
+		int[] A = new int[N];
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < N; i++) A[i] = Integer.parseInt(st.nextToken());
+		
+		int size = 0;
+		int[] LIS = new int[N];
+		for (int i = 0; i < N; i++) {
+			int num = A[i];
+			
+			int start = 0, end = size;
+			while (start < end) {
+				int mid = (start + end) / 2;
+				if (LIS[mid] < num) start = mid + 1;
+				else end = mid;
+			}
+			
+			LIS[start] = num;
+			if (start == size) size++;
+		}
+		
+		System.out.println(size);
+	}
+}

--- a/오혜윤/20250331/P12738.java
+++ b/오혜윤/20250331/P12738.java
@@ -1,0 +1,34 @@
+// [골드2] 12738번. 가장 긴 증가하는 부분 수열 3
+// 메모리 : 170056 KB, 시간 : 496 ms
+
+import java.io.*;
+import java.util.*;
+
+public class P12738 {
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		
+		int[] A = new int[N];
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < N; i++) A[i] = Integer.parseInt(st.nextToken());
+		
+		int size = 0;
+		int[] LIS = new int[N];
+		for (int i = 0; i < N; i++) {
+			int num = A[i];
+			
+			int start = 0, end = size;
+			while (start < end) {
+				int mid = (start + end) / 2;
+				if (LIS[mid] < num) start = mid + 1;
+				else end = mid;
+			}
+			
+			LIS[start] = num;
+			if (start == size) size++;
+		}
+		
+		System.out.println(size);
+	}
+}


### PR DESCRIPTION
### P2805 (0327) [나무 자르기]
- 타입 선언을 주의하자 .. sum은 long으로 선언해야 overflow 방지 가능

### P2110 (0328) [공유기 설치]
- 문제가 너무 헷갈렸어요
- 설치 가능 여부를 판단하며 이분 탐색 수행
- 집 위치 정렬 필요

### P1300 (0329) [K번째 수]
- mid 이하의 수가 몇 개인지 누적 계산
- 너무어려웟어요 ..

### P12015 (0330), P12738 (0331)
- 둘 다 동일 로직 사용 (12738번이 입력 크기만 더 큼)
- 1차원 배열에 idx가 길이일 때 최솟값을 저장 (뒤에 더 많은 큰 값이 올 수 있도록)